### PR TITLE
Dev

### DIFF
--- a/components/Layout/header/HeaderDownList.tsx
+++ b/components/Layout/header/HeaderDownList.tsx
@@ -16,7 +16,6 @@ import { notImplementedHandler } from '../../../lib/not-implemented';
 const HeaderDownList = (props: HeaderTypes) => {
   const { data: session } = useSession();
   const router = useRouter();
-  console.log(session);
 
   const loginHandler = () => {
     if (session) router.replace('/mypage');

--- a/components/home/carouselSection/CarouselSection.tsx
+++ b/components/home/carouselSection/CarouselSection.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components';
 
 import { mainCarouselState } from '../../../states/mainCarouselState';
 import { CarouselListPropsTypes } from '../../../types/home/carousel-types';
-import UseInterval from '../../../hooks/use-interval';
+import useInterval from '../../../hooks/use-interval';
 
 import CarouselButton from '../../Layout/CarouselButton';
 import CarouselSectionItem from './CarouselSectionItem';
@@ -42,7 +42,7 @@ const CarouselSection = () => {
     };
   }, [carouselNum]);
 
-  UseInterval(
+  useInterval(
     () => {
       setCarouselNum(prev => prev + 1);
       setEndPoint('');

--- a/components/login/LoginForm.tsx
+++ b/components/login/LoginForm.tsx
@@ -28,8 +28,6 @@ const LoginForm = () => {
       redirect: false,
     });
 
-    console.log(result?.error);
-
     if (result?.error) {
       alert('로그인 정보를 확인해주세요');
       setIsLoading(false);

--- a/components/mypage/home/MyPageHome.tsx
+++ b/components/mypage/home/MyPageHome.tsx
@@ -1,16 +1,14 @@
 import styled from 'styled-components';
 
-import { DataTypes } from '../../../types/common/webtoon-types';
-
 import MyPageInfo from './MyPageInfo';
 import MyPageHomeRecent from './MyPageHomeRecent';
 
-const MyPageHome = ({ recent }: { recent?: DataTypes[] }) => {
+const MyPageHome = () => {
   return (
     <section>
       <A11yHiddenTitle>마이리디 홈</A11yHiddenTitle>
       <MyPageInfo />
-      <MyPageHomeRecent recent={recent} />
+      <MyPageHomeRecent />
     </section>
   );
 };

--- a/components/mypage/home/MyPageHomeRecent.tsx
+++ b/components/mypage/home/MyPageHomeRecent.tsx
@@ -1,19 +1,23 @@
+import { ClipLoader } from 'react-spinners';
 import styled from 'styled-components';
 
+import useWebtoon from '../../../hooks/use-webtoon';
 import { DataTypes } from '../../../types/common/webtoon-types';
 
 import MyPageHomeEmptyRecent from './MyPageHomeEmptyRecent';
 import MyPageHomeRecentHeader from './MyPageHomeRecentHeader';
 import MyPageHomeRecentItem from './MyPageHomeRecentItem';
 
-const MyPageHomeRecent = ({ recent }: { recent?: DataTypes[] }) => {
+const MyPageHomeRecent = () => {
+  const { recent, isLoading } = useWebtoon();
+
   return (
     <RecentViewWrapper>
       <MyPageHomeRecentHeader />
-      {!recent?.length && <MyPageHomeEmptyRecent />}
+      {!recent?.length && !isLoading && <MyPageHomeEmptyRecent />}
       {recent?.length !== 0 && (
         <RecentBookList>
-          {recent?.map(data => (
+          {recent?.map((data: DataTypes) => (
             <MyPageHomeRecentItem
               key={data.title}
               id={data.id}
@@ -23,6 +27,11 @@ const MyPageHomeRecent = ({ recent }: { recent?: DataTypes[] }) => {
             />
           ))}
         </RecentBookList>
+      )}
+      {isLoading && (
+        <LoadingSpinner>
+          <ClipLoader color="#1e9eff" size={60} />
+        </LoadingSpinner>
       )}
     </RecentViewWrapper>
   );
@@ -39,6 +48,12 @@ const RecentBookList = styled.ul`
   gap: 40px;
   overflow: hidden;
   margin-top: 20px;
+`;
+
+const LoadingSpinner = styled.div`
+  ${({ theme }) => theme.mixins.flexCenter()};
+
+  height: 150px;
 `;
 
 export default MyPageHomeRecent;

--- a/components/mypage/recent/MyPageRecent.tsx
+++ b/components/mypage/recent/MyPageRecent.tsx
@@ -9,14 +9,14 @@ import MyPageRecentView from './MyPageRecentView';
 const MyPageRecent = ({ recent, id }: RecentTypes) => {
   const [recentWebtoon, setRecentWebtoon] = useState(recent);
 
-  const removeHandler = () => setRecentWebtoon(undefined);
+  const removeHandler = () => setRecentWebtoon([]);
 
   return (
     <RecentSection>
       <article>
         <Title>최근 조회한 작품</Title>
-        {!recentWebtoon && <MyPageRecentEmptyView />}
-        {recentWebtoon && (
+        {recentWebtoon?.length === 0 && <MyPageRecentEmptyView />}
+        {recentWebtoon?.length !== 0 && (
           <MyPageRecentView
             recent={recentWebtoon}
             id={id}

--- a/components/webtoon/WebtoonContainer.tsx
+++ b/components/webtoon/WebtoonContainer.tsx
@@ -23,7 +23,7 @@ const WebtoonContainer = ({
         title={selectedWebtoon.title}
       />
       <WebtoonKeyword />
-      <WebtoonIntroduce />
+      <WebtoonIntroduce id={selectedWebtoon.id} cover={selectedWebtoon.cover} />
       <WebtoonReview rating={selectedWebtoon.rating} />
       <WebtoonSimilar webtoon={webtoon} />
     </Wrapper>

--- a/components/webtoon/webtoonInfo/webtoonInfoBody/WebtoonThumbnail.tsx
+++ b/components/webtoon/webtoonInfo/webtoonInfoBody/WebtoonThumbnail.tsx
@@ -9,6 +9,9 @@ import { AiOutlineHeart, AiFillHeart, AiOutlineCheck } from 'react-icons/ai';
 import { BsPlusLg } from 'react-icons/bs';
 import Toaster from '../../../Layout/Toaster';
 
+const blurDataURL =
+  'data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg==';
+
 const WebtoonThumbnail = (props: DataTypes) => {
   const [favorite, setFavorite] = useState<boolean>(false);
   const [notice, setNotice] = useState<boolean>(false);
@@ -60,6 +63,8 @@ const WebtoonThumbnail = (props: DataTypes) => {
         width={200}
         height={290}
         priority
+        placeholder="blur"
+        blurDataURL={blurDataURL}
       />
       <HeartButton onClick={favoriteHandler}>
         {!favorite && <AiOutlineHeart />}

--- a/components/webtoon/webtoonIntroduce/AuthorIntroduce.tsx
+++ b/components/webtoon/webtoonIntroduce/AuthorIntroduce.tsx
@@ -2,9 +2,14 @@ import Image from 'next/image';
 import Link from 'next/link';
 import styled from 'styled-components';
 
+import { DataTypes } from '../../../types/common/webtoon-types';
+
 import ArticleMiddleTitle from '../../Layout/ArticleMiddleTitle';
 
-const AuthorIntroduce = () => {
+const blurDataURL =
+  'data:image/gif;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg==';
+
+const AuthorIntroduce = ({ id, cover }: DataTypes) => {
   return (
     <Introduce>
       <ArticleMiddleTitle>저자 소개</ArticleMiddleTitle>
@@ -23,12 +28,14 @@ const AuthorIntroduce = () => {
         <h4>대표 저서</h4>
         <RepresentativeList>
           <li>
-            <Link href="/webtoon">
+            <Link href={`/webtoon/${id}`}>
               <Image
-                src="/images/cover/bookcover12.webp"
+                src={`/images/${cover}`}
                 alt="대표웹툰"
                 width={90}
                 height={130}
+                placeholder="blur"
+                blurDataURL={blurDataURL}
               />
             </Link>
           </li>

--- a/components/webtoon/webtoonIntroduce/WebtoonIntroduce.tsx
+++ b/components/webtoon/webtoonIntroduce/WebtoonIntroduce.tsx
@@ -1,11 +1,13 @@
+import { DataTypes } from '../../../types/common/webtoon-types';
+
 import AuthorIntroduce from './AuthorIntroduce';
 import BookIntroduce from './BookIntroduce';
 
-const WebtoonIntroduce = () => {
+const WebtoonIntroduce = ({ id, cover }: DataTypes) => {
   return (
     <>
       <BookIntroduce />
-      <AuthorIntroduce />
+      <AuthorIntroduce id={id} cover={cover} />
     </>
   );
 };

--- a/hooks/use-interval.tsx
+++ b/hooks/use-interval.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const UseInterval = (
+const useInterval = (
   callback: () => void,
   delay: number,
   dependency: number
@@ -22,4 +22,4 @@ const UseInterval = (
   }, [dependency]);
 };
 
-export default UseInterval;
+export default useInterval;

--- a/hooks/use-webtoon.tsx
+++ b/hooks/use-webtoon.tsx
@@ -1,0 +1,27 @@
+import { useSession } from 'next-auth/react';
+import useSWR from 'swr';
+import { DbUserTypes } from '../types/lib/db-user-types';
+
+const useWebtoon = () => {
+  const { data: session } = useSession();
+
+  const { data: recent, error } = useSWR(
+    `${process.env.NEXT_PUBLIC_NEXTAUTH_URL}/api/recent-webtoon`,
+    url =>
+      fetch(url).then(async res => {
+        const data = await res.json();
+
+        const loginUser = data.data.find(
+          (item: DbUserTypes) => item.id === session?.user?.name
+        );
+        return loginUser.recentWebtoon;
+      })
+  );
+  return {
+    recent: recent,
+    isLoading: !error && !recent,
+    isError: error,
+  };
+};
+
+export default useWebtoon;

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^4.6.0",
         "react-slick": "^0.29.0",
+        "react-spinners": "^0.13.7",
         "recoil": "^0.7.6",
         "slick-carousel": "^1.8.1",
         "styled-components": "^5.3.6",
@@ -4865,6 +4866,15 @@
         "react-dom": "^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-spinners": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.7.tgz",
+      "integrity": "sha512-mRamn56bfxWbGcacif5RT3UbeJaXi2AttjtPwSmomuv2IcxjpbfETCzdTvaQpNDk0E33ENJsStsQeKAZFuJcpA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/recoil": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.7.6.tgz",
@@ -9462,6 +9472,12 @@
         "lodash.debounce": "^4.0.8",
         "resize-observer-polyfill": "^1.5.0"
       }
+    },
+    "react-spinners": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.7.tgz",
+      "integrity": "sha512-mRamn56bfxWbGcacif5RT3UbeJaXi2AttjtPwSmomuv2IcxjpbfETCzdTvaQpNDk0E33ENJsStsQeKAZFuJcpA==",
+      "requires": {}
     },
     "recoil": {
       "version": "0.7.6",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^4.6.0",
     "react-slick": "^0.29.0",
+    "react-spinners": "^0.13.7",
     "recoil": "^0.7.6",
     "slick-carousel": "^1.8.1",
     "styled-components": "^5.3.6",

--- a/pages/api/remove-recent.ts
+++ b/pages/api/remove-recent.ts
@@ -22,10 +22,7 @@ const handler = async (req: Request, res: NextApiResponse) => {
 
     const removeWebtoon = await db
       ?.collection('users')
-      .updateOne(
-        { _id: existingUser?._id },
-        { $unset: { recentWebtoon: true } }
-      );
+      .updateOne({ _id: existingUser?._id }, { $set: { recentWebtoon: [] } });
 
     res.status(201).json({ message: 'remove recent webtoon!' });
     client?.close();

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,11 +5,8 @@ import { getWebtoon } from '../lib/api-util';
 import Footer from '../components/Layout/footer/Footer';
 import Header from '../components/Layout/header/Header';
 import HomeContainer from '../components/home/HomeContainer';
-import { useSession } from 'next-auth/react';
 
 const HomePage = (props: InferGetStaticPropsType<typeof getStaticProps>) => {
-  const { data } = useSession();
-  // console.log(data);
   return (
     <>
       <Header webtoon={props.webtoon} />

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -1,8 +1,5 @@
 import { NextPageContext } from 'next';
-import { getSession, useSession } from 'next-auth/react';
-import useSWR from 'swr';
-
-import { DbUserTypes } from '../../types/lib/db-user-types';
+import { getSession } from 'next-auth/react';
 
 import Footer from '../../components/Layout/footer/Footer';
 import Header from '../../components/Layout/header/Header';
@@ -10,24 +7,11 @@ import MyPageContainer from '../../components/Layout/MyPageContainer';
 import MyPageHome from '../../components/mypage/home/MyPageHome';
 
 const Mypage = () => {
-  const { data: session } = useSession();
-
-  const { data: recent } = useSWR('/api/recent-webtoon', url =>
-    fetch(url).then(async res => {
-      const data = await res.json();
-
-      const loginUser = data.data.find(
-        (item: DbUserTypes) => item.id === session?.user?.name
-      );
-      return loginUser.recentWebtoon;
-    })
-  );
-
   return (
     <>
       <Header sub />
       <MyPageContainer>
-        <MyPageHome recent={recent} />
+        <MyPageHome />
       </MyPageContainer>
       <Footer />
     </>
@@ -36,7 +20,6 @@ const Mypage = () => {
 
 export const getServerSideProps = async (context: NextPageContext) => {
   const session = await getSession({ req: context.req });
-  console.log(session);
 
   if (!session) {
     return {

--- a/types/mypage/recent-webtoon-types.ts
+++ b/types/mypage/recent-webtoon-types.ts
@@ -15,6 +15,7 @@ export interface RecentWebtoonTypes {
 export interface RecentTypes {
   recent?: DataTypes[];
   id?: string | null;
+  isLoading?: boolean;
 }
 
 export interface RemoveRecentTypes extends RecentTypes {


### PR DESCRIPTION
- close #73 

최근 조회한 웹툰에 로딩스피너 추가
npm react-spinners 추가
mypage/recent는 csr로 웹툰정보를 부르는 방식에서 getServerSideProps에서 웹툰 정보를 가져오는 것으로 변경
```js
export const getServerSideProps = async (context: NextPageContext) => {
  const session = await getSession({ req: context.req });

  const response = await fetch(
    `${process.env.NEXT_PUBLIC_NEXTAUTH_URL}/api/recent-webtoon`
  );

  const data = await response.json();

  const loginUser = data.data.find(
    (item: DbUserTypes) => item.id === session?.user?.name
  );

  if (!session) {
    return {
      redirect: {
        destination: '/',
        permanent: false,
      },
    };
  }

  return {
    props: { id: session.user?.name, recent: loginUser.recentWebtoon || null },
  };
};
```